### PR TITLE
Refactor ListAsync method to return IEnumerable<string> instead of string[]

### DIFF
--- a/Devantler.KubernetesProvisioner.Cluster.Core/IKubernetesClusterProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Core/IKubernetesClusterProvisioner.cs
@@ -39,7 +39,7 @@ public interface IKubernetesClusterProvisioner
   /// </summary>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  Task<string[]> ListAsync(CancellationToken cancellationToken);
+  Task<IEnumerable<string>> ListAsync(CancellationToken cancellationToken);
 
   /// <summary>
   /// Checks if a Kubernetes cluster exists.

--- a/Devantler.KubernetesProvisioner.Cluster.K3d.Tests/K3dProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.K3d.Tests/K3dProvisionerTests/AllMethodsTests.cs
@@ -20,7 +20,7 @@ public class AllMethodsTests
 
     // Act
     var createClusterException = await Record.ExceptionAsync(async () => await _k3dProvisioner.ProvisionAsync(clusterName, configPath, CancellationToken.None).ConfigureAwait(false));
-    string[] clusters = await _k3dProvisioner.ListAsync(CancellationToken.None);
+    var clusters = await _k3dProvisioner.ListAsync(CancellationToken.None);
     var stopClusterException = await Record.ExceptionAsync(async () => await _k3dProvisioner.StopAsync(clusterName, CancellationToken.None).ConfigureAwait(false));
     var startClusterException = await Record.ExceptionAsync(async () => await _k3dProvisioner.StartAsync(clusterName, CancellationToken.None).ConfigureAwait(false));
     bool clusterExists = await _k3dProvisioner.ExistsAsync(clusterName, CancellationToken.None);

--- a/Devantler.KubernetesProvisioner.Cluster.K3d/K3dProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.K3d/K3dProvisioner.cs
@@ -16,7 +16,7 @@ public class K3dProvisioner : IKubernetesClusterProvisioner
     await K3dCLI.K3d.GetClusterAsync(clusterName, cancellationToken).ConfigureAwait(false);
 
   /// <inheritdoc />
-  public async Task<string[]> ListAsync(CancellationToken cancellationToken) =>
+  public async Task<IEnumerable<string>> ListAsync(CancellationToken cancellationToken) =>
     await K3dCLI.K3d.ListClustersAsync(cancellationToken).ConfigureAwait(false);
 
   /// <inheritdoc />

--- a/Devantler.KubernetesProvisioner.Cluster.Kind.Tests/KindProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind.Tests/KindProvisionerTests/AllMethodsTests.cs
@@ -19,7 +19,7 @@ public class AllMethodsTests
 
     // Act
     var createClusterException = await Record.ExceptionAsync(async () => await _kindProvisioner.ProvisionAsync(clusterName, configPath, CancellationToken.None).ConfigureAwait(false));
-    string[] clusters = await _kindProvisioner.ListAsync(CancellationToken.None);
+    var clusters = await _kindProvisioner.ListAsync(CancellationToken.None);
     var stopClusterException = await Record.ExceptionAsync(async () => await _kindProvisioner.StopAsync(clusterName, CancellationToken.None).ConfigureAwait(false));
     var startClusterException = await Record.ExceptionAsync(async () => await _kindProvisioner.StartAsync(clusterName, CancellationToken.None).ConfigureAwait(false));
     bool clusterExists = await _kindProvisioner.ExistsAsync(clusterName, CancellationToken.None);

--- a/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
@@ -18,12 +18,12 @@ public class KindProvisioner : IKubernetesClusterProvisioner
   /// <inheritdoc />
   public async Task<bool> ExistsAsync(string clusterName, CancellationToken cancellationToken)
   {
-    string[] clusterNames = await ListAsync(cancellationToken).ConfigureAwait(false);
+    var clusterNames = await ListAsync(cancellationToken).ConfigureAwait(false);
     return clusterNames.Contains(clusterName);
   }
 
   /// <inheritdoc />
-  public async Task<string[]> ListAsync(CancellationToken cancellationToken) =>
+  public async Task<IEnumerable<string>> ListAsync(CancellationToken cancellationToken) =>
     await KindCLI.Kind.GetClustersAsync(cancellationToken).ConfigureAwait(false);
 
   /// <inheritdoc />


### PR DESCRIPTION
This pull request refactors the `ListAsync` method in the `IKubernetesClusterProvisioner` interface to return `IEnumerable<string>` instead of `string[]`. The changes are made in multiple files, updating the return type of the method and updating the variable types in the related code. This refactoring improves the code by using a more flexible and efficient data type for the list of clusters.