### PR TITLE
Refactor interface name to use more generic term

### DIFF
--- a/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// A Kubernetes GitOps provisioner.
 /// </summary>
-public interface IKubernetesGitOpsProvisioner
+public interface IGitOpsProvisioner
 {
   /// <summary>
   /// The Kubernetes context.

--- a/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
@@ -12,7 +12,7 @@ namespace Devantler.KubernetesProvisioner.GitOps.Flux;
 /// Initializes a new instance of the <see cref="FluxProvisioner"/> class.
 /// </remarks>
 /// <param name="context"></param>
-public class FluxProvisioner(string? context = default) : IKubernetesGitOpsProvisioner
+public class FluxProvisioner(string? context = default) : IGitOpsProvisioner
 {
 
   /// <inheritdoc/>


### PR DESCRIPTION
This pull request refactors the interface name from `IKubernetesGitOpsProvisioner` to `IGitOpsProvisioner` in order to use a more generic term. This change is made in the `FluxProvisioner` class as well.