### PR TITLE
Add PushManifestsAsync method

### DIFF
--- a/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
@@ -9,6 +9,18 @@ public interface IGitOpsProvisioner
   /// The Kubernetes context.
   /// </summary>
   public string? Context { get; set; }
+
+  /// <summary>
+  /// Push manifests to an OCI registry
+  /// </summary>
+  /// <param name="registryUri"></param>
+  /// <param name="manifestsDirectory"></param>
+  /// <param name="userName"></param>
+  /// <param name="password"></param>
+  /// <param name="cancellationToken"></param>
+  /// <returns></returns>
+  public Task PushManifestsAsync(Uri registryUri, string manifestsDirectory, string? userName = default, string? password = default, CancellationToken cancellationToken = default);
+
   /// <summary>
   /// Install the GitOps tooling on the Kubernetes cluster.
   /// </summary>

--- a/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/Devantler.KubernetesProvisioner.GitOps.Flux.Tests.csproj
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/Devantler.KubernetesProvisioner.GitOps.Flux.Tests.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="0.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Devantler.KubernetesProvisioner.GitOps.Flux\Devantler.KubernetesProvisioner.GitOps.Flux.csproj" />
     <ProjectReference Include="..\Devantler.KubernetesProvisioner.Cluster.Kind\Devantler.KubernetesProvisioner.Cluster.Kind.csproj" />
   </ItemGroup>

--- a/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
@@ -18,6 +18,10 @@ public class FluxProvisioner(string? context = default) : IGitOpsProvisioner
   /// <inheritdoc/>
   public string? Context { get; set; } = context;
 
+  /// <inheritdoc/>
+  public async Task PushManifestsAsync(Uri registryUri, string manifestsDirectory, string? userName = null, string? password = null, CancellationToken cancellationToken = default) =>
+    await FluxCLI.Flux.PushArtifactAsync(registryUri, manifestsDirectory, cancellationToken: cancellationToken).ConfigureAwait(false);
+
   /// <summary>
   /// Install Flux on the Kubernetes cluster.
   /// </summary>
@@ -26,11 +30,7 @@ public class FluxProvisioner(string? context = default) : IGitOpsProvisioner
   public async Task InstallAsync(CancellationToken cancellationToken = default) =>
     await FluxCLI.Flux.InstallAsync(Context, cancellationToken).ConfigureAwait(false);
 
-  /// <summary>
-  /// Reconcile resources on the Kubernetes cluster.
-  /// </summary>
-  /// <param name="cancellationToken"></param>
-  /// <returns></returns>
+  /// <inheritdoc/>
   public async Task ReconcileAsync(CancellationToken cancellationToken = default)
   {
     using var kubernetesResourceProvisioner = new KubernetesResourceProvisioner(Context);


### PR DESCRIPTION
Refactored the IGitOpsProvisioner interface and FluxProvisioner class to add a new method, PushManifestsAsync, which allow pushing manifests to an OCI registry. Implemented the PushManifestsAsync method in the FluxProvisioner class, using the FluxCLI.Flux.PushArtifactAsync method for pushing the manifests. Also updated the FluxProvisioner class to use the new method for pushing manifests.