### PR TITLE
Rename InstallAsync to BootstrapAsync and update method signature

### DIFF
--- a/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
@@ -22,9 +22,9 @@ public interface IGitOpsProvisioner
   public Task PushManifestsAsync(Uri registryUri, string manifestsDirectory, string? userName = default, string? password = default, CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Install the GitOps tooling on the Kubernetes cluster.
+  /// Bootstrap the GitOps tooling on the Kubernetes cluster.
   /// </summary>
-  public Task InstallAsync(CancellationToken cancellationToken = default);
+  public Task BootstrapAsync(Uri ociSourceUrl, string kustomizationDirectory, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Uninstall the GitOps tooling from the Kubernetes cluster.

--- a/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/FluxProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/FluxProvisionerTests/AllMethodsTests.cs
@@ -28,12 +28,10 @@ public class AllMethodsTests
     await Kind.DeleteClusterAsync(clusterName, cancellationToken);
     await Kind.CreateClusterAsync(clusterName, configPath, cancellationToken);
     await dockerProvisioner.CreateRegistryAsync("ksail-registry", 5555, cancellationToken);
-    await fluxProvisioner.InstallAsync(cancellationToken);
+    await fluxProvisioner.BootstrapAsync(new Uri("oci://ghcr.io/stefanprodan/manifests/podinfo"), "", cancellationToken);
     string testFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
     await File.WriteAllTextAsync(testFile, "test");
     await fluxProvisioner.PushManifestsAsync(new Uri("oci://localhost:5555/test-manifest"), testFile, cancellationToken: cancellationToken);
-    await FluxCLI.Flux.CreateOCISourceAsync("podinfo", new Uri("oci://ghcr.io/stefanprodan/manifests/podinfo"), context, cancellationToken: cancellationToken);
-    await FluxCLI.Flux.CreateKustomizationAsync("podinfo", "OCIRepository/podinfo", "", context, cancellationToken: cancellationToken);
     await fluxProvisioner.ReconcileAsync(cancellationToken);
     await fluxProvisioner.UninstallAsync(cancellationToken);
 

--- a/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
@@ -25,10 +25,18 @@ public class FluxProvisioner(string? context = default) : IGitOpsProvisioner
   /// <summary>
   /// Install Flux on the Kubernetes cluster.
   /// </summary>
+  /// <param name="ociSourceUrl"></param>
+  /// <param name="kustomizationDirectory"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public async Task InstallAsync(CancellationToken cancellationToken = default) =>
+  public async Task BootstrapAsync(Uri ociSourceUrl, string kustomizationDirectory, CancellationToken cancellationToken = default)
+  {
     await FluxCLI.Flux.InstallAsync(Context, cancellationToken).ConfigureAwait(false);
+    await FluxCLI.Flux.CreateOCISourceAsync("flux-system", ociSourceUrl, cancellationToken: cancellationToken)
+      .ConfigureAwait(false);
+    await FluxCLI.Flux.CreateKustomizationAsync("flux-system", "OCIRepository/flux-system", kustomizationDirectory,
+      cancellationToken: cancellationToken).ConfigureAwait(false);
+  }
 
   /// <inheritdoc/>
   public async Task ReconcileAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
Rename the `InstallAsync` method to `BootstrapAsync` and modify its signature to include `ociSourceUrl` and `kustomizationDirectory` for improved clarity and functionality.