### PR TITLE
Update Devantler.FluxCLI to version 0.0.8

### DIFF
--- a/Devantler.KubernetesProvisioner.GitOps.Flux/Devantler.KubernetesProvisioner.GitOps.Flux.csproj
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/Devantler.KubernetesProvisioner.GitOps.Flux.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.FluxCLI" Version="0.0.7" />
+    <PackageReference Include="Devantler.FluxCLI" Version="0.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade the Devantler.FluxCLI dependency to the latest version for improved functionality and performance.