### PR TITLE
Optimize waiting time for Kubernetes operations

### DIFF
--- a/Devantler.KubernetesProvisioner.Cluster.Kind/Devantler.KubernetesProvisioner.Cluster.Kind.csproj
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind/Devantler.KubernetesProvisioner.Cluster.Kind.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Devantler.KindCLI" Version="1.0.1" />
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
+    <PackageReference Include="KubernetesClient" Version="15.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
@@ -3,7 +3,6 @@ using Docker.DotNet;
 using Docker.DotNet.Models;
 using k8s;
 using k8s.Autorest;
-using k8s.Exceptions;
 
 namespace Devantler.KubernetesProvisioner.Cluster.Kind;
 

--- a/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
@@ -9,10 +9,9 @@ namespace Devantler.KubernetesProvisioner.Cluster.Kind;
 /// <summary>
 /// A Kubernetes cluster provisioner for Kind.
 /// </summary>
-public class KindProvisioner(string? context) : IKubernetesClusterProvisioner
+public class KindProvisioner : IKubernetesClusterProvisioner
 {
   readonly DockerClient _dockerClient = new DockerClientConfiguration().CreateClient();
-  readonly Kubernetes _kubernetesClient = new(KubernetesClientConfiguration.BuildConfigFromConfigObject(KubernetesClientConfiguration.LoadKubeConfig(), context));
 
   /// <inheritdoc />
   public async Task DeprovisionAsync(string clusterName, CancellationToken cancellationToken = default) =>
@@ -52,11 +51,12 @@ public class KindProvisioner(string? context) : IKubernetesClusterProvisioner
         );
       }
     }
+    using var kubernetesClient = new Kubernetes(KubernetesClientConfiguration.BuildConfigFromConfigObject(KubernetesClientConfiguration.LoadKubeConfig(), clusterName));
     while (true)
     {
       try
       {
-        _ = await _kubernetesClient.ListNamespaceAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        _ = await kubernetesClient.ListNamespaceAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         break;
       }
       catch (KubeConfigException)

--- a/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
@@ -2,6 +2,7 @@
 using Docker.DotNet;
 using Docker.DotNet.Models;
 using k8s;
+using k8s.Autorest;
 using k8s.Exceptions;
 
 namespace Devantler.KubernetesProvisioner.Cluster.Kind;
@@ -67,6 +68,10 @@ public class KindProvisioner : IKubernetesClusterProvisioner
         await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
       }
       catch (HttpRequestException)
+      {
+        await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
+      }
+      catch (HttpOperationException)
       {
         await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
       }

--- a/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
@@ -63,10 +63,6 @@ public class KindProvisioner : IKubernetesClusterProvisioner
           break;
         }
       }
-      catch (KubeConfigException)
-      {
-        await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-      }
       catch (HttpRequestException)
       {
         await Task.Delay(1000, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Adjust the implementation to ensure that the system does not wait longer than necessary when interacting with Kubernetes, improving efficiency in the process. A new package reference for KubernetesClient has been added to support these changes.