### PR TITLE
Refactor IGitOpsProvisioner interface by removing access modifiers from method signatures

### DIFF
--- a/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
@@ -8,7 +8,7 @@ public interface IGitOpsProvisioner
   /// <summary>
   /// The Kubernetes context.
   /// </summary>
-  public string? Context { get; set; }
+  string? Context { get; set; }
 
   /// <summary>
   /// Push manifests to an OCI registry
@@ -19,20 +19,20 @@ public interface IGitOpsProvisioner
   /// <param name="password"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public Task PushManifestsAsync(Uri registryUri, string manifestsDirectory, string? userName = default, string? password = default, CancellationToken cancellationToken = default);
+  Task PushManifestsAsync(Uri registryUri, string manifestsDirectory, string? userName = default, string? password = default, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Bootstrap the GitOps tooling on the Kubernetes cluster.
   /// </summary>
-  public Task BootstrapAsync(Uri ociSourceUrl, string kustomizationDirectory, bool insecure = false, CancellationToken cancellationToken = default);
+  Task BootstrapAsync(Uri ociSourceUrl, string kustomizationDirectory, bool insecure = false, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Uninstall the GitOps tooling from the Kubernetes cluster.
   /// </summary>
-  public Task UninstallAsync(CancellationToken cancellationToken = default);
+  Task UninstallAsync(CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Reconcile resources on the Kubernetes cluster.
   /// </summary>
-  public Task ReconcileAsync(string timeout = "5m", CancellationToken cancellationToken = default);
+  Task ReconcileAsync(string timeout = "5m", CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
Simplify the IGitOpsProvisioner interface by removing public access modifiers from method signatures, enhancing readability and consistency.