### PR TITLE
Remove '--wait' argument from Flux CLI command

### DIFF
--- a/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
@@ -243,8 +243,7 @@ public partial class FluxProvisioner(string? context = default) : IGitOpsProvisi
       "--path", kustomizationDirectory,
       "--namespace", "flux-system",
       "--interval", "5m",
-      "--prune",
-      "--wait"
+      "--prune"
     };
     args.AddIfNotNull("--context={0}", Context);
     var (exitCode, _) = await FluxCLI.Flux.RunAsync([.. args], cancellationToken: cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Eliminate the '--wait' argument from the Flux CLI command to streamline the execution process.