### PR TITLE
Replace conditional with while loop for kustomization reconciliation in FluxProvisioner

### DIFF
--- a/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/Devantler.KubernetesProvisioner.GitOps.Flux.Tests.csproj
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/Devantler.KubernetesProvisioner.GitOps.Flux.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.0.*" />
+    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Devantler.KubernetesProvisioner.GitOps.Flux/Devantler.KubernetesProvisioner.GitOps.Flux.csproj
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/Devantler.KubernetesProvisioner.GitOps.Flux.csproj
@@ -13,8 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="Devantler.FluxCLI" Version="1.2.0" />
-    <PackageReference Include="MedallionTopologicalSort" Version="1.0.0" />
     <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.2.*" />
+    <PackageReference Include="Devantler.Commons.Utils" Version="0.4.0" />
+    <PackageReference Include="MedallionTopologicalSort" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
@@ -86,7 +86,7 @@ public partial class FluxProvisioner(string? context = default) : IGitOpsProvisi
             "--timeout", timeout
           };
           args.AddIfNotNull("--context={0}", Context);
-          if (kustomizationTuple.Item2.Any() && !kustomizationTuple.Item2.All(reconciledKustomizations.Contains))
+          while (kustomizationTuple.Item2.Any() && !kustomizationTuple.Item2.All(reconciledKustomizations.Contains))
           {
             Thread.Sleep(2500);
           }

--- a/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Globalization;
 using Devantler.Commons.Extensions;
+using Devantler.Commons.Utils;
 using Devantler.FluxCLI;
 using Devantler.KubernetesProvisioner.GitOps.Core;
 using Devantler.KubernetesProvisioner.Resources.Native;
@@ -89,7 +90,7 @@ public partial class FluxProvisioner(string? context = default) : IGitOpsProvisi
           var startTime = DateTime.UtcNow;
           while (kustomizationTuple.Item2.Any() && !kustomizationTuple.Item2.All(reconciledKustomizations.Contains))
           {
-            if (DateTime.UtcNow - startTime > TimeSpan.Parse(timeout))
+            if (DateTime.UtcNow - startTime > TimeSpanHelper.ParseDuration(timeout))
             {
               throw new FluxException($"Reconciliation of '{kustomizationTuple.Name}' timed out. Waiting for dependencies: {string.Join(", ", $"'{kustomizationTuple.Item2}'")}");
             }

--- a/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
@@ -91,7 +91,7 @@ public partial class FluxProvisioner(string? context = default) : IGitOpsProvisi
           {
             if (DateTime.UtcNow - startTime > TimeSpan.Parse(timeout))
             {
-              throw new TimeoutException($"Reconciliation of Kustomization {kustomizationTuple.Name} timed out.");
+              throw new FluxException($"Reconciliation of Kustomization {kustomizationTuple.Name} timed out waiting for dependencies: {string.Join(", ", kustomizationTuple.Item2)}");
             }
             await Task.Delay(2500, cancellationToken);
           }

--- a/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
@@ -91,7 +91,7 @@ public partial class FluxProvisioner(string? context = default) : IGitOpsProvisi
           {
             if (DateTime.UtcNow - startTime > TimeSpan.Parse(timeout))
             {
-              throw new FluxException($"Reconciliation of Kustomization {kustomizationTuple.Name} timed out waiting for dependencies: {string.Join(", ", kustomizationTuple.Item2)}");
+              throw new FluxException($"Reconciliation of '{kustomizationTuple.Name}' timed out. Waiting for dependencies: {string.Join(", ", $"'{kustomizationTuple.Item2}'")}");
             }
             await Task.Delay(2500, cancellationToken);
           }


### PR DESCRIPTION
Refactor the kustomization reconciliation logic to use a while loop instead of a conditional statement, improving the handling of reconciliation checks.